### PR TITLE
Bugfix/issue#11

### DIFF
--- a/RandomStudy/Cells/TodayTableViewCell.swift
+++ b/RandomStudy/Cells/TodayTableViewCell.swift
@@ -82,15 +82,15 @@ class TodayTableViewCell: UITableViewCell {
     private func setLayout() {
         let size: CGFloat = contentView.frame.size.height
         
-        checkBtn.rightAnchor.constraint(equalTo: contentView.rightAnchor, constant: -10).isActive = true
-        checkBtn.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 25).isActive = true
-        checkBtn.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -25).isActive = true
-        checkBtn.widthAnchor.constraint(equalToConstant: size/2).isActive = true
+        checkBtn.centerYAnchor.constraint(equalTo: contentView.centerYAnchor).isActive = true
+        checkBtn.rightAnchor.constraint(equalTo: contentView.rightAnchor, constant: -16).isActive = true
+        checkBtn.widthAnchor.constraint(equalToConstant: size / 3 * 2).isActive = true
+        checkBtn.heightAnchor.constraint(equalToConstant: size / 3 * 2).isActive = true
         
-        deleteBtn.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 25).isActive = true
-        deleteBtn.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -25).isActive = true
-        deleteBtn.rightAnchor.constraint(equalTo: checkBtn.leftAnchor, constant: -10).isActive = true
-        deleteBtn.widthAnchor.constraint(equalToConstant: size/2).isActive = true
+        deleteBtn.centerYAnchor.constraint(equalTo: contentView.centerYAnchor).isActive = true
+        deleteBtn.rightAnchor.constraint(equalTo: checkBtn.leftAnchor, constant: -16).isActive = true
+        deleteBtn.widthAnchor.constraint(equalToConstant: size / 3 * 2).isActive = true
+        deleteBtn.heightAnchor.constraint(equalToConstant: size / 3 * 2).isActive = true
         
         label.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20).isActive = true
         label.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
@@ -103,6 +103,7 @@ class TodayTableViewCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         selectionStyle = .none
+        contentView.backgroundColor = .white
         contentView.addSubview(label)
         contentView.addSubview(deleteBtn)
         contentView.addSubview(checkBtn)

--- a/RandomStudy/Cells/TodayTableViewCell.swift
+++ b/RandomStudy/Cells/TodayTableViewCell.swift
@@ -22,11 +22,13 @@ class TodayTableViewCell: UITableViewCell {
     // 체크버튼
     @objc func checkButtonTapped() {
         delegate?.checkButtonTapped(value: item)
-        checkView.isHidden = false
-        // 애니메이션 실행
-        checkView.play{ (finish) in
-            self.checkView.currentProgress = 20
-            self.contentView.backgroundColor = .lightGray
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+            if self?.item?.isDone == true {
+                self?.checkView.isHidden = false
+                self?.contentView.backgroundColor = .lightGray
+                // 애니메이션 실행
+                self?.checkView.play()
+            }
         }
     }
     // 삭제버튼


### PR DESCRIPTION
### 해결방법
- isDone이 true인 경우에만 로띠 실행되도록 수정
- 추가적으로 삭제 / 체크 버튼의 UI가 깨지는 것 수정

### 시나리오
- 1번째 아이템 선택 시 5번째 아이템 로띠 실행 안되도록 수정 완료
- 2번째 아이템 선택 시 4번째 아이템 로띠 실행 안되도록 수정 완료
- 3번째 아이템 선택 시 3번째 아이템 로띠만 실행되는 것 확인

### 추가 수정 필요한 부분
- 2번째 아이템의 isDone이 true인 경우 4번째 아이템 선택 시 2번째 아이템 로띠 실행되고 있음

### 수정 방향
- 완료 목록을 CompletionList로 관리하는 것이 아닌 TodayStudyList의 isDone이 true인 아이템만 가져오도록 처리

### 영상

https://github.com/minjae-L/RandomStudy/assets/37168358/9d933550-d5e5-4430-ae0d-6701bf181992