### PR TITLE
Feature/reset btn setting vc

### DIFF
--- a/RandomStudy/Cells/SettingTableViewCell.swift
+++ b/RandomStudy/Cells/SettingTableViewCell.swift
@@ -42,7 +42,6 @@ class SettingTableViewCell: UITableViewCell {
         iconContainer.addSubview(iconImageView)
         
         contentView.clipsToBounds = true
-        accessoryType = .disclosureIndicator
     }
     
     required init?(coder: NSCoder) {
@@ -78,5 +77,6 @@ class SettingTableViewCell: UITableViewCell {
         label.text = model.title
         iconImageView.image = model.icon
         iconContainer.backgroundColor = model.iconBackgroundColor
+        self.accessoryType = model.accessoryType
     }
 }

--- a/RandomStudy/Controllers/SettingViewController.swift
+++ b/RandomStudy/Controllers/SettingViewController.swift
@@ -65,7 +65,15 @@ class SettingViewController: UIViewController {
                 let vc = HistoryViewController()
                 self.navigationController?.pushViewController(vc, animated: true)
             }, accessoryType: .disclosureIndicator)),
-            .staticCell(model: SettingsOption(title: "기록 초기화", icon: UIImage(systemName: "trash"), iconBackgroundColor: .systemRed, handler: {}, accessoryType: .none))
+            .staticCell(model: SettingsOption(title: "기록 초기화", icon: UIImage(systemName: "trash"), iconBackgroundColor: .systemRed, handler: {
+                StudyListUserDefaults.shared.removeAll()
+                TodayStudyUserDefauls.shared.removeAll()
+                HistoryUserDefaults.shared.removeAll()
+                let alert = UIAlertController(title: "초기화", message: "초기화하였습니다.", preferredStyle: .alert)
+                let okAction = UIAlertAction(title: "확인", style: .default)
+                alert.addAction(okAction)
+                self.present(alert, animated: true)
+            }, accessoryType: .none))
         ]))
         
     }

--- a/RandomStudy/Controllers/SettingViewController.swift
+++ b/RandomStudy/Controllers/SettingViewController.swift
@@ -64,8 +64,8 @@ class SettingViewController: UIViewController {
             .staticCell(model: SettingsOption(title: "내 기록", icon: UIImage(systemName: "checklist.checked"), iconBackgroundColor: .systemGreen, handler: {
                 let vc = HistoryViewController()
                 self.navigationController?.pushViewController(vc, animated: true)
-            })),
-            .staticCell(model: SettingsOption(title: "기록 초기화", icon: UIImage(systemName: "trash"), iconBackgroundColor: .systemRed, handler: {}))
+            }, accessoryType: .disclosureIndicator)),
+            .staticCell(model: SettingsOption(title: "기록 초기화", icon: UIImage(systemName: "trash"), iconBackgroundColor: .systemRed, handler: {}, accessoryType: .none))
         ]))
         
     }

--- a/RandomStudy/Controllers/SettingViewController.swift
+++ b/RandomStudy/Controllers/SettingViewController.swift
@@ -66,16 +66,21 @@ class SettingViewController: UIViewController {
                 self.navigationController?.pushViewController(vc, animated: true)
             }, accessoryType: .disclosureIndicator)),
             .staticCell(model: SettingsOption(title: "기록 초기화", icon: UIImage(systemName: "trash"), iconBackgroundColor: .systemRed, handler: {
-                StudyListUserDefaults.shared.removeAll()
-                TodayStudyUserDefauls.shared.removeAll()
-                HistoryUserDefaults.shared.removeAll()
-                let alert = UIAlertController(title: "초기화", message: "초기화하였습니다.", preferredStyle: .alert)
-                let okAction = UIAlertAction(title: "확인", style: .default)
-                alert.addAction(okAction)
-                self.present(alert, animated: true)
+                self.removeAllButtonEvent()
             }, accessoryType: .none))
         ]))
         
+    }
+    
+    private func removeAllButtonEvent() {
+        StudyListUserDefaults.shared.removeAll()
+        TodayStudyUserDefauls.shared.removeAll()
+        HistoryUserDefaults.shared.removeAll()
+        
+        let alert = UIAlertController(title: "초기화", message: "초기화하였습니다.", preferredStyle: .alert)
+        let okAction = UIAlertAction(title: "확인", style: .default)
+        alert.addAction(okAction)
+        self.present(alert, animated: true)
     }
 
 }

--- a/RandomStudy/Controllers/SettingViewController.swift
+++ b/RandomStudy/Controllers/SettingViewController.swift
@@ -59,12 +59,13 @@ class SettingViewController: UIViewController {
     // 설정 목록
     private func configure() {
         models.append(Section(title: "일반", options: [
-            .switchCell(model: SettingSwitchOption(title: "다크 모드", icon: UIImage(systemName: "moon"), iconBackgroundColor: .systemRed, handler: {
+            .switchCell(model: SettingSwitchOption(title: "다크 모드", icon: UIImage(systemName: "moon"), iconBackgroundColor: .systemPurple, handler: {
             }, isOn: false)),
             .staticCell(model: SettingsOption(title: "내 기록", icon: UIImage(systemName: "checklist.checked"), iconBackgroundColor: .systemGreen, handler: {
                 let vc = HistoryViewController()
                 self.navigationController?.pushViewController(vc, animated: true)
-            }))
+            })),
+            .staticCell(model: SettingsOption(title: "기록 초기화", icon: UIImage(systemName: "trash"), iconBackgroundColor: .systemRed, handler: {}))
         ]))
         
     }

--- a/RandomStudy/Controllers/TodayViewController.swift
+++ b/RandomStudy/Controllers/TodayViewController.swift
@@ -121,7 +121,6 @@ final class TodayViewController: UIViewController {
             alert.addAction(okAction)
             viewModel.removeAll()
         }
-
     }
     
     @objc private func goSettingVC() {

--- a/RandomStudy/Models/DataModel.swift
+++ b/RandomStudy/Models/DataModel.swift
@@ -146,6 +146,7 @@ struct SettingsOption {
     let icon: UIImage?
     let iconBackgroundColor: UIColor
     let handler: (()-> Void)
+    let accessoryType: UITableViewCell.AccessoryType
 }
 
 

--- a/RandomStudy/Models/DataModel.swift
+++ b/RandomStudy/Models/DataModel.swift
@@ -72,7 +72,7 @@ class StudyListUserDefaults {
         data = new
     }
     func removeAll() {
-        UserDefaults.standard.removeObject(forKey: "studyList")
+        data.removeAll()
     }
 }
 
@@ -95,7 +95,7 @@ class TodayStudyUserDefauls {
         data = new
     }
     func removeAll() {
-        UserDefaults.standard.removeObject(forKey: "todayStudy")
+        data.removeAll()
     }
 }
 
@@ -118,7 +118,7 @@ class HistoryUserDefaults {
         data = new
     }
     func removeAll() {
-        UserDefaults.standard.removeObject(forKey: "completionStudy")
+        data.removeAll()
     }
 }
 

--- a/RandomStudy/ViewModels/AddViewModel.swift
+++ b/RandomStudy/ViewModels/AddViewModel.swift
@@ -7,30 +7,6 @@
 
 import Foundation
 
-// Observable 선언
-class Observable<T> {
-    // 3. 호출되면, 2번에서 받은 값을 전달.
-    private var listener: ((T) -> Void)?
-    
-    // 2. value에 값이 설정되면, listener에 해당값을 전달
-    var value: T {
-        didSet {
-            listener?(value)
-        }
-    }
-    // 1. 초기화함수로 값을 입력받고, value 에 저장.
-    init(_ value: T) {
-        self.value = value
-    }
-    
-    // 4. 다른곳에서 bind라는 메소드를 호출하면, value에 저장된 값을 전달,
-    // 전달받은 closure 표현식을 listener에 할당
-    func bind(_ closure: @escaping (T) -> Void) {
-        closure(value)
-        listener = closure
-    }
-}
-
 protocol AddViewModelDelegate: AnyObject {
     func didUpdate(with value: [Study])
 }


### PR DESCRIPTION
설정의 초기화 버튼 생성
- 모든 데이터를 지우는 기능
-싱글톤 유저디폴드의 값을 빈배열로 바꿔버림

문제점
- AddVC 와 HistoryVC는 뷰를 새로 열면서 UI를 그리기에 초기화버튼을 누르면 삭제가 잘 되어있음
- TodayVC -> SettingVC로 push하여 삭제버튼을 눌렀더니 다시 dismiss하여 TodayVC로 왔더니 여전히 UI는 그려져있음( 데이터가 남아있음)
- 하지만 싱글톤 유저디폴트는 빈배열임 아마도 뷰모델안의 데이터는 수정되지않았다.


생각해봐야할 해결방안
- SettingVC에서 TodayVC의 뷰모델안 데이터를 변경시킬 방법을 찾아봐야 한다??
- SettingVC에서 어떻게 TodayVC의 뷰모델 데이터를 접근할 수 있을까?
- 아예 다르게 하는 방법 찾아보기



