### PR TITLE
Feature/lottie animation

### DIFF
--- a/RandomStudy/Cells/TodayTableViewCell.swift
+++ b/RandomStudy/Cells/TodayTableViewCell.swift
@@ -20,7 +20,6 @@ class TodayTableViewCell: UITableViewCell {
     var name: String = ""
     // 체크버튼
     @objc func checkButtonTapped() {
-        self.checkView.isHidden = false
         checkView.play()
         delegate?.checkButtonTapped(name: self.name)
     }
@@ -63,16 +62,6 @@ class TodayTableViewCell: UITableViewCell {
         view.translatesAutoresizingMaskIntoConstraints = false
         view.widthAnchor.constraint(equalToConstant: 80).isActive = true
         view.heightAnchor.constraint(equalToConstant: 80).isActive = true
-        view.isHidden = true
-        return view
-    }()
-    private let completedCheckView: LottieAnimationView = {
-        let view = LottieAnimationView(name: "check")
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.widthAnchor.constraint(equalToConstant: 80).isActive = true
-        view.heightAnchor.constraint(equalToConstant: 80).isActive = true
-        view.currentProgress = 20
-        
         return view
     }()
     private func setupButtonEvent() {
@@ -99,8 +88,6 @@ class TodayTableViewCell: UITableViewCell {
         label.trailingAnchor.constraint(equalTo: deleteBtn.leadingAnchor).isActive = true
         checkView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor).isActive = true
         checkView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor).isActive = true
-        completedCheckView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor).isActive = true
-        completedCheckView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor).isActive = true
     }
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -110,7 +97,6 @@ class TodayTableViewCell: UITableViewCell {
         contentView.addSubview(deleteBtn)
         contentView.addSubview(checkBtn)
         contentView.addSubview(checkView)
-        contentView.addSubview(completedCheckView)
         setLayout()
         setupButtonEvent()
     }
@@ -124,17 +110,14 @@ class TodayTableViewCell: UITableViewCell {
     
     override func prepareForReuse() {
         label.text = nil
+        checkView.currentProgress = 0
     }
     func configure(with model: FirebaseDataModel) {
         self.name = model.name
         label.text = model.name
         guard let done = model.done else { return }
-        
-        completedCheckView.isHidden = true
-        checkView.isHidden = true
         if done {
-            completedCheckView.isHidden = false
-            checkView.isHidden = true
+            checkView.currentProgress = 1
         }
     }
 

--- a/RandomStudy/Cells/TodayTableViewCell.swift
+++ b/RandomStudy/Cells/TodayTableViewCell.swift
@@ -18,10 +18,11 @@ class TodayTableViewCell: UITableViewCell {
     weak var delegate: TodayTableViewCellDelegate?
     
     var name: String = ""
-    
     // 체크버튼
     @objc func checkButtonTapped() {
-        delegate?.checkButtonTapped(name: name)
+        self.checkView.isHidden = false
+        checkView.play()
+        delegate?.checkButtonTapped(name: self.name)
     }
     // 삭제버튼
     @objc func deleteButtonTapped() {
@@ -63,10 +64,17 @@ class TodayTableViewCell: UITableViewCell {
         view.widthAnchor.constraint(equalToConstant: 80).isActive = true
         view.heightAnchor.constraint(equalToConstant: 80).isActive = true
         view.isHidden = true
+        return view
+    }()
+    private let completedCheckView: LottieAnimationView = {
+        let view = LottieAnimationView(name: "check")
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.widthAnchor.constraint(equalToConstant: 80).isActive = true
+        view.heightAnchor.constraint(equalToConstant: 80).isActive = true
+        view.currentProgress = 20
         
         return view
     }()
-    
     private func setupButtonEvent() {
         checkBtn.addTarget(self, action: #selector(checkButtonTapped), for: .touchUpInside)
         deleteBtn.addTarget(self, action: #selector(deleteButtonTapped), for: .touchUpInside)
@@ -91,6 +99,8 @@ class TodayTableViewCell: UITableViewCell {
         label.trailingAnchor.constraint(equalTo: deleteBtn.leadingAnchor).isActive = true
         checkView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor).isActive = true
         checkView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor).isActive = true
+        completedCheckView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor).isActive = true
+        completedCheckView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor).isActive = true
     }
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -100,6 +110,7 @@ class TodayTableViewCell: UITableViewCell {
         contentView.addSubview(deleteBtn)
         contentView.addSubview(checkBtn)
         contentView.addSubview(checkView)
+        contentView.addSubview(completedCheckView)
         setLayout()
         setupButtonEvent()
     }
@@ -113,22 +124,17 @@ class TodayTableViewCell: UITableViewCell {
     
     override func prepareForReuse() {
         label.text = nil
-        checkView.isHidden = true
     }
-    
     func configure(with model: FirebaseDataModel) {
         self.name = model.name
         label.text = model.name
         guard let done = model.done else { return }
-        if !done {
-            checkBtn.isEnabled = true
+        
+        completedCheckView.isHidden = true
+        checkView.isHidden = true
+        if done {
+            completedCheckView.isHidden = false
             checkView.isHidden = true
-            contentView.backgroundColor = UIColor(named: "CellBackgroundColor")
-        } else {
-            contentView.backgroundColor = .gray
-            checkBtn.isEnabled = false
-            checkView.isHidden = false
-            checkView.currentProgress = 20
         }
     }
 

--- a/RandomStudy/ViewModels/TodayViewModel.swift
+++ b/RandomStudy/ViewModels/TodayViewModel.swift
@@ -18,7 +18,6 @@ final class TodayViewModel {
     // MARK: Property
     weak var delegate: TodayViewModelDelegate?
     private let db = Firestore.firestore()
-    
     private(set) var todo: [FirebaseDataModel] = [] {
         didSet {
             delegate?.didUpdateToday()
@@ -75,10 +74,7 @@ final class TodayViewModel {
         } catch {
             print("TodayVM:: Complete Fail")
         }
-        self.fetchData()
-        
     }
-    // 체크 버튼 이벤트
     func insertDataToHistory(completion: FirebaseDataModel) {
         guard let uid = Auth.auth().currentUser?.uid else { return }
         let data = [["name": completion.name, "done": true, "date": dateFommatter.string(from: Date())]]
@@ -96,7 +92,7 @@ final class TodayViewModel {
         let data = todo.filter{$0.name == name}[0]
         let removed = [["name": data.name, "done": data.done]]
         do {
-            try db.collection("users").document(uid).updateData(["todo": FieldValue.arrayRemove(removed)])
+            try db.collection("users").document(uid).updateData(["data": FieldValue.arrayRemove(removed)])
             print("TodayVM:: Remove Success")
         } catch {
             print("TodayVM:: Remove Fail")


### PR DESCRIPTION
# 기획
### 1.  셀 안에 있는 체크버튼 클릭 시 체크 애니메이션이 재생된다.
### 2. 애니메이션이 종료되면 체크표시가 버튼을 누른 셀에 남아서 완료되었다는 표시를 남긴다.
## 버그발생 
### 1. 셀안에 있는 체크버튼 클릭시 애니메이션이 재생되자마자 체크표시가 남겨진다.(재생이 안됨)
### 2. 체크버튼을 누르면 애니메이션이 재생되었지만, 재생 후 다른 셀에 체크표시가 남겨진다.
### 3. 체크버튼클릭후 애니메이션 재생도중에 다른 뷰로 넘어가면 해당 데이터가 완료표시가 되지 않는다.

### 이전 구성방식
- 1.셀안에 들어가는 데이터는 `configure(model: DataModel)`메서드구현하여 `tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath)`메서드 안에서 셀 UI구성
- 2.완료여부를 확인하는 `done`변수가 `true`면 체크표시가 남도록 설계
- 3.데이터의 값이 변경되거나 추가되면 `tableView.reloadData()`로 셀과 데이터바인딩
- 4.Lottie메서드중 play을 completion으로 받는 클로저에서 재생완료 후 done을 true로 바꾸도록 설계
--> 값이 변경되자마자 애니메이션 재생되려다가 reloadData가 실행되어 재생없이 체크표시가 남겨지게됨
--> 데이터바인딩이 되서 값이 변경될때마다 `tableView.reloadData()`이 여러번호출되서 재생완료된 후 다른 셀에 체크표시가 남게됨
--> 클로저로 completion받기전에 다른 뷰로 이동하여 done값이 true로 수정되지않음


### 해결방식
- 1.두개의 LottieAnimationView생성 하나는 애니메이션 재생하는 뷰, 나머지 하나는 재생 후 완료표시를 위한 뷰
- 2.cell은 재사용되기 때문에 두개의 뷰는 `isHidden = true`로 기본값 설정
- 3.애니메이션이 재생될 때만 `isHidden = false`로 수정하여 재생
- 4.재생이 완료되면 재생뷰는 숨김처리하고 완료표시뷰를 나타낸다.
- 5.체크버튼을 누르는 행위는 해당 할 일을 완료했을 때 누르는것으로 Firebase로 최신 데이터 전송만 하고, `tableView.reloadData()`메서드를 호출하지 않는다.
- 6.완료된 목록들은 `viewWillAppear()`메서드를 통해 데이터최신화가 이루어지도록 설계