### PR TITLE
Feature/data structure

### DIFF
--- a/RandomStudy/Cells/TodayTableViewCell.swift
+++ b/RandomStudy/Cells/TodayTableViewCell.swift
@@ -20,8 +20,8 @@ class TodayTableViewCell: UITableViewCell {
     var name: String = ""
     // 체크버튼
     @objc func checkButtonTapped() {
-        checkView.play()
         delegate?.checkButtonTapped(name: self.name)
+        checkView.play()
     }
     // 삭제버튼
     @objc func deleteButtonTapped() {
@@ -111,6 +111,7 @@ class TodayTableViewCell: UITableViewCell {
     override func prepareForReuse() {
         label.text = nil
         checkView.currentProgress = 0
+        checkBtn.isEnabled = true
     }
     func configure(with model: FirebaseDataModel) {
         self.name = model.name
@@ -118,6 +119,7 @@ class TodayTableViewCell: UITableViewCell {
         guard let done = model.done else { return }
         if done {
             checkView.currentProgress = 1
+            checkBtn.isEnabled = false
         }
     }
 

--- a/RandomStudy/Controllers/AddPopUpViewController.swift
+++ b/RandomStudy/Controllers/AddPopUpViewController.swift
@@ -142,7 +142,7 @@ class AddPopUpViewController: UIViewController {
             errorLabel.isHidden = false
         } else {
             errorLabel.isHidden = true
-            viewModel.insert(str: text)
+            viewModel.insert(name: text)
             delegate?.sendedDataFromPopUp()
             self.dismiss(animated: true)
         }

--- a/RandomStudy/Controllers/AddPopUpViewController.swift
+++ b/RandomStudy/Controllers/AddPopUpViewController.swift
@@ -142,7 +142,7 @@ class AddPopUpViewController: UIViewController {
             errorLabel.isHidden = false
         } else {
             errorLabel.isHidden = true
-            viewModel.addData(str: text)
+            viewModel.insert(str: text)
             delegate?.sendedDataFromPopUp()
             self.dismiss(animated: true)
         }

--- a/RandomStudy/Controllers/AddViewController.swift
+++ b/RandomStudy/Controllers/AddViewController.swift
@@ -78,7 +78,7 @@ extension AddViewController: AddPopUpViewControllerDelegate {
 
 extension AddViewController: AddViewControllerButtonDelegate {
     func cellDeleteButtonTapped(name: String) {
-        viewModel.removeData(name: name)
+        viewModel.remove(name: name)
     }
 }
 extension AddViewController: AddViewModelDelegate {

--- a/RandomStudy/Controllers/LoginViewController.swift
+++ b/RandomStudy/Controllers/LoginViewController.swift
@@ -181,6 +181,7 @@ class LoginViewController: UIViewController {
                 if result {
                     // 로그인 성공하면 uid 문서 생성(이미 있다면 생성하지않음)
                     self.viewModel.makeFirebaseDocument()
+                    self.viewModel.fetchData()
                     let navigationController = UINavigationController(rootViewController: TodayViewController())
                     navigationController.modalPresentationStyle = .fullScreen
                     self.present(navigationController, animated: true)

--- a/RandomStudy/Controllers/SettingViewController.swift
+++ b/RandomStudy/Controllers/SettingViewController.swift
@@ -122,7 +122,7 @@ class SettingViewController: UIViewController {
     }
     
     private func removeAllButtonEvent() {
-        FirebaseManager.shared.removeFirebaseData()
+        FirebaseManager.shared.removeAllData()
         self.showMessageAlert("초기화 되었습니다.")
     }
 

--- a/RandomStudy/Controllers/SettingViewController.swift
+++ b/RandomStudy/Controllers/SettingViewController.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import FirebaseAuth
 
 // MARK: - Main
 class SettingViewController: UIViewController {
@@ -105,16 +104,12 @@ class SettingViewController: UIViewController {
                                               icon: nil,
                                               iconBackgroundColor: .clear,
                                               handler: {
-                                                  do {
-                                                      try Auth.auth().signOut()
-                                                      self.showReConfirmAlert("정말 로그아웃하시겠습니까?") { confirm in
-                                                          if confirm {
-                                                              self.navigationController?.popToRootViewController(animated: false)
-                                                              self.view.window!.rootViewController?.dismiss(animated: true, completion: nil)
-                                                          }
+                                                  self.showReConfirmAlert("정말 로그아웃하시겠습니까?") { confirm in
+                                                      if confirm {
+                                                          FirebaseManager.shared.logout()
+                                                          self.navigationController?.popToRootViewController(animated: false)
+                                                          self.view.window!.rootViewController?.dismiss(animated: true,completion: nil)
                                                       }
-                                                  }catch {
-                                                      print("logout fail")
                                                   }
                                               },
                                               accessoryType: .none

--- a/RandomStudy/Controllers/TodayViewController.swift
+++ b/RandomStudy/Controllers/TodayViewController.swift
@@ -87,19 +87,24 @@ final class TodayViewController: UIViewController {
         btn.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
         btn.addTarget(self, action: #selector(fetchStudyList), for: .touchUpInside)
     }
-    
+    // 로그인 후 메인화면 첫 진입시 데이터 바로 불러오고 UI로 띄우기
+    private func firstConnetionDataload() {
+        self.showSpinner { [weak self] in
+            guard let self = self else { return }
+            self.viewModel.fetchData()
+            self.hideSpinner { }
+        }
+    }
     override func viewDidLoad() {
         super.viewDidLoad()
         addView()
         bindings()
         isPreviousDataExist()
-    }
-    override func viewWillAppear(_ animated: Bool) {
-        viewModel.fetchData()
+        firstConnetionDataload()
         settingUI()
         configureNavigationbar()
     }
-    
+    	
     @objc private func goSettingVC() {
         let vc = SettingViewController()
         self.navigationController?.pushViewController(vc, animated: true)

--- a/RandomStudy/Controllers/TodayViewController.swift
+++ b/RandomStudy/Controllers/TodayViewController.swift
@@ -93,7 +93,6 @@ final class TodayViewController: UIViewController {
         addView()
         bindings()
         isPreviousDataExist()
-        print("TodayVC:: todo: \(viewModel.todo)")
     }
     override func viewWillAppear(_ animated: Bool) {
         viewModel.fetchData()
@@ -147,7 +146,6 @@ extension TodayViewController: UITableViewDataSource, UITableViewDelegate {
         }
         
         let study = viewModel.todo[indexPath.row]
-        print("study: \(study)")
         cell.setUIColor()
         cell.delegate = self
         cell.configure(with: study)

--- a/RandomStudy/Firebase/FirebaseManager.swift
+++ b/RandomStudy/Firebase/FirebaseManager.swift
@@ -9,16 +9,12 @@ import Foundation
 import FirebaseAuth
 import FirebaseFirestore
 
-protocol FirebaseManagerDelegate: AnyObject {
-    func didFinishedDataUploading()
-}
 class FirebaseManager {
     private let db = Firestore.firestore()
     static let shared = FirebaseManager()
     private let tableNames = ["study", "todo", "history"]
     private let column = ["name", "done", "date"]
     private var uid: String
-    weak var delegate: FirebaseManagerDelegate?
     var elements = [FirebaseDataModel]()
     init () {
         print("FirebaseManager init")
@@ -48,11 +44,10 @@ class FirebaseManager {
         print("firebaseManager fetchData")
         self.getDataFromFirebase() { [weak self] data in
             self?.elements = data ?? []
-            self?.delegate?.didFinishedDataUploading()
         }
     }
     // Firebase로부터 데이터 불러오기
-    func getDataFromFirebase(completion: @escaping ([FirebaseDataModel]?) -> ()) {
+    private func getDataFromFirebase(completion: @escaping ([FirebaseDataModel]?) -> ()) {
         guard let uid = Auth.auth().currentUser?.uid else {
             completion(nil)
             return

--- a/RandomStudy/Firebase/FirebaseManager.swift
+++ b/RandomStudy/Firebase/FirebaseManager.swift
@@ -118,6 +118,47 @@ class FirebaseManager {
         db.collection("users").document(uid).updateData(["data": FieldValue.delete()])
         print("FirebaseManager:: All Data Removed")
     }
+    // 로그인
+    func login(email: String, password: String, completion: @escaping (Bool, String) -> Void) {
+        Auth.auth().signIn(withEmail: email, password: password) { AuthDataResult, error in	
+            if let error = error {
+                print("Login Fail")
+                let authError = error as NSError
+                if let ac = AuthErrorCode.Code(rawValue: authError.code) {
+                    switch ac {
+                    case .wrongPassword:
+                        completion(false, "비밀번호가 일치하지 않습니다.")
+                    case .invalidEmail:
+                        completion(false, "이메일 형식이 올바르지 않습니다.")
+                    case .userDisabled:
+                        completion(false, "이 계정은 현재 사용중지 상태입니다.")
+                    case .operationNotAllowed:
+                        completion(false, "현재 이메일 로그인을 지원하지 않습니다.")
+                    default:
+                        completion(false, "로그인 실패\n이메일과 비밀번호를 확인해주세요.")
+                    }
+                }
+            } else {
+                print("Login Success")
+                completion(true, "")
+            }
+        }
+    }
+    // uid문서 생성
+    func makeFirebaeDocument() {
+        db.collection("users").document(self.uid).getDocument { [weak self] snapshot, error in
+            guard let self = self else { return }
+            if error != nil {
+                let error = error?.localizedDescription
+                print("FirebaseManager:: makeFirebaseDocument Error: \(String(describing: error))")
+                return
+            }
+            if snapshot?.data() == nil {
+                db.collection("users").document(self.uid).setData(["uid": self.uid])
+                print("FirebaseManager:: makeFirebaseDocument Success")
+            }
+        }
+    }
 }
 
 // MARK: Data Migration

--- a/RandomStudy/Firebase/FirebaseManager.swift
+++ b/RandomStudy/Firebase/FirebaseManager.swift
@@ -173,6 +173,14 @@ class FirebaseManager {
             }
         }
     }
+    // 로그아웃
+    func logout() {
+        do {
+            try Auth.auth().signOut()
+        } catch {
+            print("logout Error")
+        }
+    }
 
 }
 

--- a/RandomStudy/Firebase/FirebaseManager.swift
+++ b/RandomStudy/Firebase/FirebaseManager.swift
@@ -24,6 +24,17 @@ class FirebaseManager {
         print("FirebaseManager init")
         self.uid = Auth.auth().currentUser?.uid ?? ""
     }
+    
+    func getFilteredData(type: DataModelType) -> [FirebaseDataModel] {
+        switch type {
+        case .todo:
+            return elements.filter{$0.date == nil && $0.done == nil }
+        case .today:
+            return elements.filter{$0.date == nil && $0.done != nil }
+        case .history:
+            return elements.filter{$0.date != nil && $0.done != nil }
+        }
+    }
 //    MARK: Method
     // 내부DB에 데이터가 존재하는지 확인하는 함수
     func isDataExist() -> Bool{

--- a/RandomStudy/Firebase/FirebaseManager.swift
+++ b/RandomStudy/Firebase/FirebaseManager.swift
@@ -31,50 +31,8 @@ class FirebaseManager {
             completion(user?.uid)
         }
     }
-    // 데이터 마이그레이션
-    func dataMigration() {
-        print("Firebase:: dataMigration:: Excuted")
-        self.getUserInfo { [weak self] uid in
-            guard let self = self,
-                  let uid = uid
-            else { return }
-            do {
-                try Firestore.firestore().collection("users").document(uid).updateData(["data": FieldValue.arrayUnion(getDataFromSQLite())])
-                print("Firebase:: dataMigration:: success written document")
-            } catch {
-                print("Firebase:: dataMigration:: fail writing document")
-            }
-            DBHelper.shared.resetAllTable()
-        }
-    }
-    // 마이그레이션 전에 SQLite로부터 데이터 불러오기
-    func getDataFromSQLite() -> [[String: Any]]{
-        var dataArray = [[String: Any]]()
-        var data = DBHelper.shared.readData(tableName: "todo", column: column)
-        
-        if !data.isEmpty {
-            for j in data {
-                dataArray.append(["name": j.name!])
-            }
-        }
-        
-        data = DBHelper.shared.readData(tableName: "study", column: column)
-        if !data.isEmpty {
-            for j in data {
-                dataArray.append(["name": j.name!, "done": (j.done == "0" ? false : true)])
-            }
-        }
-        
-        data = DBHelper.shared.readData(tableName: "history", column: column)
-        if !data.isEmpty {
-            for j in data {
-                dataArray.append(["name": j.name!, "done": true, "date": j.date!])
-            }
-        }
-        return dataArray
-    }
     // Firebase로부터 데이터 불러오기
-    func getDataFromFirebase(dataName: String, completion: @escaping ([FirebaseDataModel]?) -> ()) {
+    func getDataFromFirebase(completion: @escaping ([FirebaseDataModel]?) -> ()) {
         guard let uid = Auth.auth().currentUser?.uid else {
             completion(nil)
             return
@@ -118,5 +76,39 @@ class FirebaseManager {
         } catch {
             print("DBHelper:: do delete fail")
         }
+
+// MARK: Data Migration
+extension FirebaseManager {
+    // 데이터 마이그레이션
+    func dataMigration() {
+        print("Firebase:: dataMigration:: Excuted")
+        Firestore.firestore().collection("users").document(uid).updateData(["data": FieldValue.arrayUnion(getDataFromSQLite())])
+        DBHelper.shared.resetAllTable()
+    }
+    // 마이그레이션 전에 SQLite로부터 데이터 불러오기
+    func getDataFromSQLite() -> [[String: Any]]{
+        var dataArray = [[String: Any]]()
+        var data = DBHelper.shared.readData(tableName: "todo", column: column)
+        
+        if !data.isEmpty {
+            for j in data {
+                dataArray.append(["name": j.name!])
+            }
+        }
+        
+        data = DBHelper.shared.readData(tableName: "study", column: column)
+        if !data.isEmpty {
+            for j in data {
+                dataArray.append(["name": j.name!, "done": (j.done == "0" ? false : true)])
+            }
+        }
+        
+        data = DBHelper.shared.readData(tableName: "history", column: column)
+        if !data.isEmpty {
+            for j in data {
+                dataArray.append(["name": j.name!, "done": true, "date": j.date!])
+            }
+        }
+        return dataArray
     }
 }

--- a/RandomStudy/Firebase/FirebaseManager.swift
+++ b/RandomStudy/Firebase/FirebaseManager.swift
@@ -31,7 +31,7 @@ class FirebaseManager {
             return elements.filter{$0.date != nil && $0.done != nil }
         }
     }
-//    MARK: Method
+//    MARK: - Data Method
     // 내부DB에 데이터가 존재하는지 확인하는 함수
     func isDataExist() -> Bool{
         for i in tableNames {
@@ -118,6 +118,35 @@ class FirebaseManager {
         db.collection("users").document(uid).updateData(["data": FieldValue.delete()])
         print("FirebaseManager:: All Data Removed")
     }
+    // uid문서 생성
+    func makeFirebaeDocument() {
+        db.collection("users").document(self.uid).getDocument { [weak self] snapshot, error in
+            guard let self = self else { return }
+            if error != nil {
+                let error = error?.localizedDescription
+                print("FirebaseManager:: makeFirebaseDocument Error: \(String(describing: error))")
+                return
+            }
+            if snapshot?.data() == nil {
+                db.collection("users").document(self.uid).setData(["uid": self.uid])
+                print("FirebaseManager:: makeFirebaseDocument Success")
+            }
+        }
+    }
+    // MARK: Auth Methods
+    // 회원가입
+    func signUp(email: String, password: String, completion: @escaping (Bool, String) -> Void) {
+        Auth.auth().createUser(withEmail: email, password: password) { authResult, error in
+            guard let user = authResult?.user, error == nil else {
+                print("Create User Fail")
+                guard let authError = error as? NSError else { return }
+                completion(false, authError.localizedDescription)
+                return
+            }
+            completion(true, "")
+            print("Created User")
+        }
+    }
     // 로그인
     func login(email: String, password: String, completion: @escaping (Bool, String) -> Void) {
         Auth.auth().signIn(withEmail: email, password: password) { AuthDataResult, error in	
@@ -144,21 +173,7 @@ class FirebaseManager {
             }
         }
     }
-    // uid문서 생성
-    func makeFirebaeDocument() {
-        db.collection("users").document(self.uid).getDocument { [weak self] snapshot, error in
-            guard let self = self else { return }
-            if error != nil {
-                let error = error?.localizedDescription
-                print("FirebaseManager:: makeFirebaseDocument Error: \(String(describing: error))")
-                return
-            }
-            if snapshot?.data() == nil {
-                db.collection("users").document(self.uid).setData(["uid": self.uid])
-                print("FirebaseManager:: makeFirebaseDocument Success")
-            }
-        }
-    }
+
 }
 
 // MARK: Data Migration

--- a/RandomStudy/Models/DataModel.swift
+++ b/RandomStudy/Models/DataModel.swift
@@ -28,7 +28,7 @@ struct FirebaseDataModel: Equatable, Codable {
     }
 }
 
-// GitSearch 데이터 모델
+    // GitSearch 데이터 모델
 struct GitSearchRepository: Codable {
     let repositoryItems: [GitSearchItems]
     

--- a/RandomStudy/Models/DataModel.swift
+++ b/RandomStudy/Models/DataModel.swift
@@ -18,6 +18,11 @@ struct StudyModel: Equatable, Codable {
         return lhs.name == rhs.name
     }
 }
+enum DataModelType {
+    case todo
+    case today
+    case history
+}
 struct FirebaseDataModel: Equatable, Codable {
     let name: String
     var done: Bool?

--- a/RandomStudy/ViewModels/AddViewModel.swift
+++ b/RandomStudy/ViewModels/AddViewModel.swift
@@ -41,9 +41,9 @@ final class AddViewModel {
     }
     
     // 배열에 값 추가
-    func insert(str: String) {
-        if str == "" { return }
-        let data = FirebaseDataModel(name: str)
+    func insert(name: String) {
+        if name == "" { return }
+        let data = FirebaseDataModel(name: name)
         FirebaseManager.shared.setDataToFirebase(data: data)
         self.fetchData()
     }

--- a/RandomStudy/ViewModels/AddViewModel.swift
+++ b/RandomStudy/ViewModels/AddViewModel.swift
@@ -6,8 +6,6 @@
 //
 
 import Foundation
-import FirebaseAuth
-import FirebaseFirestore
 
 protocol AddViewModelDelegate: AnyObject {
     func didUpdate(with value: [FirebaseDataModel])
@@ -16,7 +14,6 @@ protocol AddViewModelDelegate: AnyObject {
 final class AddViewModel {
     
     weak var delegate: AddViewModelDelegate?
-    private let db = Firestore.firestore()
     private var elements: [FirebaseDataModel] = [] {
         didSet {
             delegate?.didUpdate(with: elements)
@@ -56,8 +53,7 @@ final class AddViewModel {
         self.fetchData()
     }
     func fetchData() {
-        let arr = FirebaseManager.shared.elements.filter{ $0.date == nil && $0.done == nil}
-        self.elements = arr
+        self.elements = FirebaseManager.shared.getFilteredData(type: .todo)
     }
 }
 

--- a/RandomStudy/ViewModels/AddViewModel.swift
+++ b/RandomStudy/ViewModels/AddViewModel.swift
@@ -44,42 +44,20 @@ final class AddViewModel {
     }
     
     // 배열에 값 추가
-    func addData(str: String) {
+    func insert(str: String) {
         if str == "" { return }
-        guard let uid = Auth.auth().currentUser?.uid else { return }
-        let data: [[String: String]] = [["name": str]]
-        do {
-            try db.collection("users").document(uid).updateData(["data": FieldValue.arrayUnion(data)])
-            print("addVM:: Success Data Write")
-        } catch {
-            print("addVM:: Fail Data Write")
-        }
+        let data = FirebaseDataModel(name: str)
+        FirebaseManager.shared.setDataToFirebase(data: data)
         self.fetchData()
     }
-    
-    func removeData(name: String) {
-        guard let uid = Auth.auth().currentUser?.uid else { return }
-        let removed: [[String: String]] = [["name": name]]
-        print("AddVM:: removed: \(removed)")
-        do {
-            try db.collection("users").document(uid).updateData(["data": FieldValue.arrayRemove(removed)])
-            print("addVM:: Success Data Removed")
-        } catch {
-            print("addVM:: Fail Data Removed")
-        }
+    func remove(name: String) {
+        let data = FirebaseDataModel(name: name)
+        FirebaseManager.shared.removeDataFromFirebase(data: data)
         self.fetchData()
     }
     func fetchData() {
-        FirebaseManager.shared.getDataFromFirebase(dataName: "data") { [weak self] dataModel in
-            guard let self = self, let data = dataModel else {
-                self?.elements = []
-                return
-            }
-            self.elements = data.filter{$0.date == nil && $0.done == nil}
-        }
+        let arr = FirebaseManager.shared.elements.filter{ $0.date == nil && $0.done == nil}
+        self.elements = arr
     }
 }
-
-
-
 

--- a/RandomStudy/ViewModels/HistoryViewModel.swift
+++ b/RandomStudy/ViewModels/HistoryViewModel.swift
@@ -33,11 +33,6 @@ final class HistoryViewModel {
         return Array(Set(completions.compactMap { $0.date })).sorted()
     }
     private func fetchData() {
-        FirebaseManager.shared.getDataFromFirebase() { [weak self] dataModel in
-            guard let self = self,
-                  let data = dataModel
-            else { return }
-            self.completions = data.filter{$0.date != nil && $0.done != nil}
-        }
+        completions = FirebaseManager.shared.getFilteredData(type: .history)
     }
 }

--- a/RandomStudy/ViewModels/HistoryViewModel.swift
+++ b/RandomStudy/ViewModels/HistoryViewModel.swift
@@ -33,7 +33,7 @@ final class HistoryViewModel {
         return Array(Set(completions.compactMap { $0.date })).sorted()
     }
     private func fetchData() {
-        FirebaseManager.shared.getDataFromFirebase(dataName: "data") { [weak self] dataModel in
+        FirebaseManager.shared.getDataFromFirebase() { [weak self] dataModel in
             guard let self = self,
                   let data = dataModel
             else { return }

--- a/RandomStudy/ViewModels/LoginViewModel.swift
+++ b/RandomStudy/ViewModels/LoginViewModel.swift
@@ -48,7 +48,6 @@ class LoginViewModel {
             if error != nil {
                 print("LoginVM:: maekFirebaseDocument Error")
             }
-            print("LoginVM:: snapshot: \(snapshot?.data())")
             // 로그인한 uid의 문서가 존재하지 않는다면 생성해준다.
             if snapshot?.data() == nil {
                 print("LoginVM:: firebase document is nil")
@@ -61,6 +60,11 @@ class LoginViewModel {
             }
             
         }
+    }
+    // 해당 계정의 데이터 불러오기
+    func fetchData() {
+        print("loginVM:: fetchData")
+        FirebaseManager.shared.fetchData()
     }
 
 }

--- a/RandomStudy/ViewModels/LoginViewModel.swift
+++ b/RandomStudy/ViewModels/LoginViewModel.swift
@@ -6,60 +6,22 @@
 //
 
 import Foundation
-import FirebaseAuth
-import FirebaseFirestore
 
 class LoginViewModel {
 //  MARK: Method
     // 로그인
-    func login(email: String, password: String, completion: @escaping (Bool,String) -> Void) {
+    func login(email: String, password: String, completion: @escaping (Bool, String) -> Void ) {
         if email.isEmpty || password.isEmpty {
             completion(false, "이메일 혹은 비밀번호를 입력해주세요.")
             return
         }
-        Auth.auth().signIn(withEmail: email, password: password) { authResult, error in
-            if let error = error {
-                let authError = error as NSError
-                if let ac = AuthErrorCode.Code(rawValue: authError.code) {
-                    switch ac {
-                    case .wrongPassword:
-                        completion(false, "비밀번호가 일치하지 않습니다.")
-                    case .invalidEmail:
-                        completion(false, "이메일 형식이 올바르지 않습니다.")
-                    case .userDisabled:
-                        completion(false, "이 계정은 현재 사용중지 상태입니다.")
-                    case .operationNotAllowed:
-                        completion(false, "현재 이메일 로그인을 지원하지 않습니다.")
-                    default:
-                        completion(false, "로그인 실패\n이메일과 비밀번호를 확인해주세요.")
-                    }
-                }
-            } else {
-                completion(true, "")
-            }
-            
+        FirebaseManager.shared.login(email: email, password: password) { (result, message) -> Void in
+            completion(result, message)
         }
     }
     // uid 문서 생성
     func makeFirebaseDocument() {
-        guard let uid = Auth.auth().currentUser?.uid else { return }
-        let db = Firestore.firestore()
-        db.collection("users").document(uid).getDocument { snapshot, error in
-            if error != nil {
-                print("LoginVM:: maekFirebaseDocument Error")
-            }
-            // 로그인한 uid의 문서가 존재하지 않는다면 생성해준다.
-            if snapshot?.data() == nil {
-                print("LoginVM:: firebase document is nil")
-                do {
-                    try db.collection("users").document(uid).setData(["uid": uid])
-                    print("LoginVM:: make document success")
-                } catch {
-                    print("LoginVM:: make document Error")
-                }
-            }
-            
-        }
+        FirebaseManager.shared.makeFirebaeDocument()
     }
     // 해당 계정의 데이터 불러오기
     func fetchData() {

--- a/RandomStudy/ViewModels/SignUpViewModel.swift
+++ b/RandomStudy/ViewModels/SignUpViewModel.swift
@@ -6,11 +6,10 @@
 //
 
 import Foundation
-import FirebaseAuth
 
 class SignUpViewModel {
     // 회원가입
-    func signUp(email: String, password: String, confirmPassword: String, completion: @escaping (Bool,String) -> Void) {
+    func signUp(email: String, password: String, confirmPassword: String, completion: @escaping (Bool, String) -> Void) {
         if email.isEmpty {
             completion(false, "이메일을 입력해주세요.")
             return
@@ -23,16 +22,8 @@ class SignUpViewModel {
             completion(false, "비밀번호가 일치하지 않습니다.")
             return
         }
-
-        Auth.auth().createUser(withEmail: email, password: password) { authResult, error in
-            guard let user = authResult?.user, error == nil else {
-                print("Create User Fail")
-                guard let authError = error as? NSError else { return }
-                completion(false, authError.localizedDescription)
-                return
-            }
-            completion(true, "")
-            print("Created User")
+        FirebaseManager.shared.signUp(email: email, password: password) { (result, message) -> Void in
+            completion(result, message)
         }
     }
 }

--- a/RandomStudy/ViewModels/TodayViewModel.swift
+++ b/RandomStudy/ViewModels/TodayViewModel.swift
@@ -21,13 +21,6 @@ final class TodayViewModel {
             delegate?.didUpdateToday()
         }
     }
-    
-    init() {
-        print("today viewmodel init")
-        self.fetchData()
-        FirebaseManager.shared.delegate = self
-    }
-    
     private var dateFommatter: DateFormatter = {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "YYYY년MM월dd일"
@@ -73,13 +66,5 @@ final class TodayViewModel {
     // 데이터 최신화
     func fetchData() {
         self.todo = FirebaseManager.shared.getFilteredData(type: .today)
-    }
-}
-
-extension TodayViewModel: FirebaseManagerDelegate {
-    func didFinishedDataUploading() {
-        print("firebaseManagerDelegate")
-        self.fetchData()
-        delegate?.didUpdateToday()
     }
 }

--- a/RandomStudy/ViewModels/TodayViewModel.swift
+++ b/RandomStudy/ViewModels/TodayViewModel.swift
@@ -6,8 +6,6 @@
 //
 
 import Foundation
-import FirebaseAuth
-import FirebaseFirestore
 
 protocol TodayViewModelDelegate: AnyObject {
     func didUpdateToday()
@@ -17,7 +15,6 @@ final class TodayViewModel {
      
     // MARK: Property
     weak var delegate: TodayViewModelDelegate?
-    private let db = Firestore.firestore()
     private(set) var todo: [FirebaseDataModel] = [] {
         didSet {
             print("todo didset")
@@ -45,7 +42,7 @@ final class TodayViewModel {
     // MARK: Method
     // 추가한 공부목록으로 부터 불러오는 메소드 (불러오기)
     func uploadStudy() {
-        let arr = FirebaseManager.shared.elements.filter{ $0.done == nil && $0.date == nil}.map{$0.name}
+        let arr = FirebaseManager.shared.getFilteredData(type: .todo).map{$0.name}
         let strArray = self.todo.map{$0.name}
         for element in arr {
             if !strArray.contains(element) {
@@ -69,27 +66,14 @@ final class TodayViewModel {
     // 삭제버튼 이벤트
     func remove(name: String) {
         guard let data = todo.filter{$0.name == name && $0.date == nil }.first else { return }
-        
         print("data: \(data)")
         FirebaseManager.shared.removeDataFromFirebase(data: data)
         self.fetchData()
     }
     // 데이터 최신화
     func fetchData() {
-        let arr = FirebaseManager.shared.elements
-        self.todo = arr.filter{$0.date == nil && $0.done != nil}
-        print("*** Fetched Data in TodayVC")
-        print("- FirebaseManager.elements")
-        for i in arr {
-            print(i)
-        }
-        print("- fetched todo")
-        for i in todo {
-            print(i)
-        }
+        self.todo = FirebaseManager.shared.getFilteredData(type: .today)
     }
-    
-    
 }
 
 extension TodayViewModel: FirebaseManagerDelegate {

--- a/RandomStudy/ViewModels/TodayViewModel.swift
+++ b/RandomStudy/ViewModels/TodayViewModel.swift
@@ -55,12 +55,12 @@ final class TodayViewModel {
     
     // 완료 버튼 이벤트
     func complete(name: String) {
-        let previous = FirebaseDataModel(name: name, done: false, date: nil)
-        let next = FirebaseDataModel(name: name, done: true, date: nil)
-        let completion = FirebaseDataModel(name: name, done: true, date: dateFommatter.string(from: Date()))
-        FirebaseManager.shared.removeDataFromFirebase(data: previous)
-        FirebaseManager.shared.setDataToFirebase(data: next)
-        FirebaseManager.shared.setDataToFirebase(data: completion)
+        let todayData = FirebaseDataModel(name: name, done: false, date: nil)
+        let completedTodayData = FirebaseDataModel(name: name, done: true, date: nil)
+        let historyData = FirebaseDataModel(name: name, done: true, date: dateFommatter.string(from: Date()))
+        FirebaseManager.shared.removeDataFromFirebase(data: todayData)
+        FirebaseManager.shared.setDataToFirebase(data: completedTodayData)
+        FirebaseManager.shared.setDataToFirebase(data: historyData)
     }
     
     // 삭제버튼 이벤트

--- a/RandomStudy/ViewModels/TodayViewModel.swift
+++ b/RandomStudy/ViewModels/TodayViewModel.swift
@@ -27,6 +27,7 @@ final class TodayViewModel {
     init() {
         print("today viewmodel init")
         self.fetchData()
+        FirebaseManager.shared.delegate = self
     }
     
     private var dateFommatter: DateFormatter = {
@@ -109,4 +110,10 @@ final class TodayViewModel {
         }
     }
     
+extension TodayViewModel: FirebaseManagerDelegate {
+    func didFinishedDataUploading() {
+        print("firebaseManagerDelegate")
+        self.fetchData()
+        delegate?.didUpdateToday()
+    }
 }


### PR DESCRIPTION
- ViewModel에서 Firebase로 직접 접근하던 방식에서 FirebaseManager의 접근메서드 호출하는 방식으로 변경
- ViewModel에서 `import FirebaseAuth, import FirebaseFirestore` 제거
- 이전 방식은 매번 VC접근마다 해당 ViewModel에서 Firebase의 데이터를 직접 불러오는 방식을 사용 (뷰 이동마다 데이터 호출)
- 로그인시 해당 유저의 저장된 데이터를 한번에 불러와서 저장, 매번 다른 VC로 이동시 데이터 호출하던 방식을 제거
- 한번에 불러온 모든 데이터를 필터 메서드를 통해 각 VC에 맞는 데이터로 변환하여 사용
